### PR TITLE
Add eigen and tl-optional as run dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 739731e1eb83194c4977fa946ee63ba1aa8aadf757d67f3b183f2dfab64eff81
 
 build:
-  number: 2
+  number: 3
 
 outputs:
   - name: manif
@@ -27,6 +27,9 @@ outputs:
         - tl-optional
         - gtest
         - gmock
+      run:
+        - eigen
+        - tl-optional
     test:
       commands:
         - test -f ${PREFIX}/include/manif/manif.h  # [not win]


### PR DESCRIPTION
Fix https://github.com/conda-forge/manif-feedstock/issues/10 .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
