### PR TITLE
Remove overconstraint of numpy dependency

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -14,11 +14,6 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-numpy:
-- '1.21'
-- '1.23'
-- '1.20'
-- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -35,5 +30,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - python
-  - numpy

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -18,11 +18,6 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
-numpy:
-- '1.21'
-- '1.23'
-- '1.20'
-- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -39,5 +34,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - python
-  - numpy

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -14,11 +14,6 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
-numpy:
-- '1.21'
-- '1.23'
-- '1.20'
-- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -35,5 +30,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - python
-  - numpy

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -14,11 +14,6 @@ cxx_compiler_version:
 - '14'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-numpy:
-- '1.21'
-- '1.23'
-- '1.20'
-- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -35,5 +30,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - python
-  - numpy

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -6,11 +6,6 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
-numpy:
-- '1.21'
-- '1.23'
-- '1.20'
-- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -24,6 +19,3 @@ python:
 - 3.9.* *_cpython
 target_platform:
 - win-64
-zip_keys:
-- - python
-  - numpy

--- a/recipe/233.patch
+++ b/recipe/233.patch
@@ -18,7 +18,7 @@ index e9ed4a38..bf32f7bc 100644
  option(BUILD_TESTING_PYTHON "Build Python tests only." OFF)
  
  if (BUILD_PYTHON_BINDINGS)
-+  find_package(Python3 COMPONENTS Interpreter Development NumPy REQUIRED)
++  find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
    find_package(pybind11 REQUIRED)
    add_subdirectory(python)
  endif()

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
       - 248.patch
 
 build:
-  number: 11
+  number: 12
 
 outputs:
   - name: manif
@@ -52,7 +52,6 @@ outputs:
         - cmake
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-        - numpy                                  # [build_platform != target_platform]
         - clang 13  # [win]
         - lld 13  # [win]
         - llvm-tools 13  # [win]
@@ -61,12 +60,11 @@ outputs:
         - tl-optional
         - python
         - pip
-        - numpy
         - pybind11
         - pybind11-abi
       run:
         - python
-        - {{ pin_compatible('numpy', max_pin='x.x') }}
+        - numpy
     test:
       imports:
         - manifpy


### PR DESCRIPTION
`manifpy` interacts with numpy only via pybind11, however as one can read in https://pybind11.readthedocs.io/en/stable/advanced/pycpp/numpy.html : 
> Note that pybind11/numpy.h does not depend on the NumPy headers, and thus can be used without declaring a build-time dependency on NumPy; NumPy>=1.7.0 is a runtime dependency.

That means that we do not need to declare numpy as an host dependency, and the numpy dependency at runtime is without any particular constraint.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
