### PR TITLE
Remove spurious dependency of manif on Python when cross-compiling

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,9 +22,6 @@ outputs:
     script: bld_cxx.bat  # [win]
     requirements:
       build:
-        - python                                 # [build_platform != target_platform]
-        - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-        - pybind11                               # [build_platform != target_platform]
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - ninja

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
       - 248.patch
 
 build:
-  number: 14
+  number: 15
 
 outputs:
   - name: manif


### PR DESCRIPTION
For some reason, when cross-compiling manif was depending on Python, this is creating problem such as https://github.com/conda-forge/bipedal-locomotion-framework-feedstock/pull/32#issuecomment-1622594939 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
