### PR TITLE
Ignore gtest and gmock run_exports and ensure that manif and manifpy have the same version via run_contrained

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ outputs:
         - eigen
         - tl-optional
       run_constrained:
-        - manif {{ version }}
+        - manifpy {{ version }}
     test:
       commands:
         - test -f ${PREFIX}/include/manif/manif.h  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,12 +12,19 @@ source:
       - 305.patch
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: manif
     script: build_cxx.sh  # [unix]
     script: bld_cxx.bat  # [win]
+    build:
+      # gtest and gmock are used for tests
+      # manif also has a gtest helper public header, but anyhow
+      # if downstream users want to use it, they can just install gtest
+      ignore_run_exports_from:
+        - gtest
+        - gmock
     requirements:
       build:
         - {{ compiler('c') }}
@@ -33,6 +40,8 @@ outputs:
       run:
         - eigen
         - tl-optional
+      run_constrained:
+        - manif {{ version }}
     test:
       commands:
         - test -f ${PREFIX}/include/manif/manif.h  # [not win]
@@ -70,6 +79,8 @@ outputs:
         - numpy
       run:
         - python
+      run_constrained:
+        - manif {{ version }}
     test:
       imports:
         - manifpy


### PR DESCRIPTION
Fix two issues emerged in https://github.com/ami-iit/bipedal-locomotion-framework/issues/882 .

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
